### PR TITLE
v2.6.5 (iOS)

### DIFF
--- a/ios/ondato_flutter.podspec
+++ b/ios/ondato_flutter.podspec
@@ -3,8 +3,8 @@
 # Run `pod lib lint ondato_flutter.podspec` to validate before publishing.
 #
 
-ondato_version = '2.6.0'
-ondato_flutter_version = '2.6.1'
+ondato_version = '2.6.5'
+ondato_flutter_version = '2.6.5'
 Pod::Spec.new do |s|
   s.name             = 'ondato_flutter'
   s.version          = ondato_flutter_version

--- a/ondato_flutter_nfc_reader/ios/ondato_flutter_nfc_reader.podspec
+++ b/ondato_flutter_nfc_reader/ios/ondato_flutter_nfc_reader.podspec
@@ -2,8 +2,8 @@
 # To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html.
 # Run `pod lib lint ondato_flutter_nfc_reader.podspec` to validate before publishing.
 #
-ondato_version = '2.6.0'
-ondato_flutter_version = '2.6.1'
+ondato_version = '2.6.5'
+ondato_flutter_version = '2.6.5'
 Pod::Spec.new do |s|
   s.name             = 'ondato_flutter_nfc_reader'
   s.version          = ondato_flutter_version

--- a/ondato_flutter_screen_recorder/ios/ondato_flutter_screen_recorder.podspec
+++ b/ondato_flutter_screen_recorder/ios/ondato_flutter_screen_recorder.podspec
@@ -2,8 +2,8 @@
 # To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html.
 # Run `pod lib lint ondato_flutter_screen_recorder.podspec` to validate before publishing.
 #
-ondato_version = '2.6.0'
-ondato_flutter_version = '2.6.1'
+ondato_version = '2.6.5'
+ondato_flutter_version = '2.6.5'
 Pod::Spec.new do |s|
   s.name             = 'ondato_flutter_screen_recorder'
   s.version          = ondato_flutter_version


### PR DESCRIPTION
- Fixed situation when recording interruption (i.e. app moving to background) occurs during face capture. Previously no interruption screen presented - resulting in erratic behavior and no screen recording uploaded.
- Updated default consent text